### PR TITLE
Improve ease of use by improving structure of lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 angular2-spaces/*
 lib/.baseDir.ts
 .tscache
-typings/*
 
 # Node generated files
 

--- a/lib/spaces_logging.service.ts
+++ b/lib/spaces_logging.service.ts
@@ -2,7 +2,7 @@
 import { Injectable } from '@angular/core';
 
 /* Third-Party */
-import { Device } from 'ng2-device-detector';
+import { BowserService } from 'ngx-bowser';
 
 @Injectable()
 export class SpacesLoggingService {
@@ -39,9 +39,9 @@ export class SpacesLoggingService {
     }
 
     constructor(
-        private device: Device
+        private bowser: BowserService
     ) { 
-        this.browser = this.device.browser;
+        this.browser = this.bowser.bowser.name.toLowerCase();
         this.info('Browser', this.browser);
     }
 

--- a/main.ts
+++ b/main.ts
@@ -1,6 +1,34 @@
-export * from './lib/spaces_base.service';
-export * from './lib/spaces_logging.service';
-export * from './lib/spaces_messages.service';
-export * from './lib/spaces_request.service';
-export * from './lib/spaces_storage.service';
-export * from './lib/spaces_utilities.service';
+import { NgModule } from '@angular/core';
+
+import { SpacesBaseService } from './lib/spaces_base.service';
+import { SpacesLoggingService } from './lib/spaces_logging.service';
+import { SpacesMessagesService } from './lib/spaces_messages.service';
+import { SpacesRequestService } from './lib/spaces_request.service';
+import { SpacesStorageService } from './lib/spaces_storage.service';
+import { SpacesUtilityService } from './lib/spaces_utilities.service';
+
+// Third part
+import { Device } from 'ng2-device-detector';
+
+@NgModule({
+    providers: [
+        SpacesBaseService,
+        SpacesLoggingService,
+        SpacesMessagesService,
+        SpacesRequestService,
+        SpacesStorageService,
+        SpacesUtilityService,
+        Device,
+    ]
+})
+class SpacesModule { }
+
+export {
+    SpacesBaseService,
+    SpacesLoggingService,
+    SpacesMessagesService,
+    SpacesRequestService,
+    SpacesStorageService,
+    SpacesUtilityService,
+    SpacesModule,
+}

--- a/main.ts
+++ b/main.ts
@@ -8,9 +8,12 @@ import { SpacesStorageService } from './lib/spaces_storage.service';
 import { SpacesUtilityService } from './lib/spaces_utilities.service';
 
 // Third part
-import { Device } from 'ng2-device-detector';
+import { BowserModule } from 'ngx-bowser';
 
 @NgModule({
+    imports: [
+        BowserModule,
+    ],
     providers: [
         SpacesBaseService,
         SpacesLoggingService,
@@ -18,7 +21,6 @@ import { Device } from 'ng2-device-detector';
         SpacesRequestService,
         SpacesStorageService,
         SpacesUtilityService,
-        Device,
     ]
 })
 class SpacesModule { }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "angular2"
   ],
   "license": "Apache-2.0",
-  "main": "main.js",
+  "main": "dist/main.js",
   "maintainers": [
     {
       "email": "bsummers@threatconnect.com",
@@ -65,7 +65,7 @@
       "name": "Chris Blades"
     }
   ],
-  "name": "angular2-spaces-src",
+  "name": "angular2-spaces",
   "optionalDependencies": {},
   "peerDependencies": {},
   "readme": "",
@@ -75,9 +75,9 @@
   },
   "scripts": {
     "preinstall": "typings install",
-    "postinstall": "tsc && mv dist ../angular2-spaces",
+    "postinstall": "tsc",
     "test": "npm test"
   },
-  "typings": "./typings/index.d.ts",
+  "typings": "./main.ts",
   "version": "0.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -78,6 +78,6 @@
     "postinstall": "tsc",
     "test": "npm test"
   },
-  "typings": "./main.ts",
+  "typings": "dist/main.d.ts",
   "version": "0.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "@angular/platform-browser-dynamic": "2.4.5",
     "@angular/router": "3.4.5",
     "@angular/upgrade": "2.4.5",
+    "@types/core-js": "^0.9.41",
+    "@types/jasmine": "^2.5.47",
     "codelyzer": "^2.0.0-beta.4",
     "core-js": "^2.4.0",
     "grunt": "^1.0.1",
@@ -74,7 +76,6 @@
     "url": "git@bitbucket.org:threatconnectinc/angular2-spaces.git"
   },
   "scripts": {
-    "preinstall": "typings install",
     "postinstall": "tsc",
     "test": "npm test"
   },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@angular/router": "3.4.5",
     "@angular/upgrade": "2.4.5",
     "@types/core-js": "^0.9.41",
-    "@types/jasmine": "^2.5.47",
     "codelyzer": "^2.0.0-beta.4",
     "core-js": "^2.4.0",
     "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     }
   ],
   "dependencies": {
-    "ng2-device-detector": "^0.1.0",
+    "ngx-bowser": "^0.1.0",
     "primeng": "2.0.0",
     "primeui": "^4.1.15"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declaration": false,
+    "declaration": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "module": "commonjs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,6 @@
     "node_modules"
   ],
   "files": [
-    "main.ts"
+    "./main.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,21 @@
 {
   "compilerOptions": {
+    "declaration": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": false,
     "outDir": "dist",
     "removeComments": false,
     "sourceMap": false,
-    "target": "ES5"
+    "target": "es5",
+    "typeRoots": [
+      "node_modules/@types"
+    ],
+    "lib": [
+      "es2016",
+      "dom"
+    ]
   },
   "compileOnSave": false,
   "buildOnSave": false,
@@ -16,9 +23,5 @@
     ".c9",
     "dist",
     "node_modules"
-  ],
-  "files": [
-    "./typings/index.d.ts",
-    "./main.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "module": "commonjs",
@@ -17,9 +16,5 @@
     ".c9",
     "dist",
     "node_modules"
-  ],
-  "files": [
-    "./typings/index.d.ts",
-    "./main.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,9 @@
     ".c9",
     "dist",
     "node_modules"
+  ],
+  "files": [
+    "./typings/index.d.ts",
+    "./main.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,8 @@
     ".c9",
     "dist",
     "node_modules"
+  ],
+  "files": [
+    "main.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "declaration": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": false,
     "outDir": "dist",

--- a/typings.json
+++ b/typings.json
@@ -1,7 +1,0 @@
-{
-  "globalDependencies": {
-    "core-js": "registry:dt/core-js#0.9.7+20161130133742",
-    "jasmine": "registry:dt/jasmine#2.5.0+20170117213604",
-    "marked": "registry:dt/marked#0.0.0+20160510002910"
-  }
-}


### PR DESCRIPTION
We believe these changes would make the angular2-spaces lib easier to import and use. 

We have not changed any of the functionality, only structure, typing and exports.

* Stop moving directories when compiling lib.
* Stop using `typings` lib since it can cause conflicts with the proper @types.
* Stop using `ng2-device-detector` as this dependency is using `typings` aswell.
* Export `SpacesModule` to allow easier bootstraping in angular.