### PR TITLE
Fix: Apps crashing in IE/Edge

### DIFF
--- a/lib/spaces_logging.service.ts
+++ b/lib/spaces_logging.service.ts
@@ -164,7 +164,8 @@ export class SpacesLoggingService {
         if (!methodName) {
             // try to get method name from the stack
             let methodIndex = this.methodIndex();
-            let logStack = (new Error).stack.split('\n');
+            const error = new Error;
+            let logStack = error.stack ? error.stack.split('\n') : [];
             if (logStack.length > 0) {
                 let caller = this.parseLogLine(logStack[methodIndex]);
                 methodName = caller.method;
@@ -190,7 +191,8 @@ export class SpacesLoggingService {
          */
         if (!moduleName) {
             let methodIndex = this.methodIndex();
-            let logStack = (new Error).stack.split('\n');
+            const error = new Error;
+            let logStack = error.stack ? error.stack.split('\n') : [];
             if (logStack.length > 0) {
                 let caller = this.parseLogLine(logStack[methodIndex]);
                 moduleName = caller.module;
@@ -228,7 +230,8 @@ export class SpacesLoggingService {
         let levelNo = this.levels[level];
         
         if (levelNo >= this._logLevel) {
-            let logStack = ((new Error).stack || '').split('\n');
+            const error = new Error;
+            let logStack = error.stack ? error.stack.split('\n') : [];
             
             if (methodIndex == undefined) {
                 methodIndex = this.methodIndex();

--- a/lib/spaces_logging.service.ts
+++ b/lib/spaces_logging.service.ts
@@ -369,7 +369,7 @@ export class SpacesLoggingService {
                 }
                 break;
             default:
-                this.warn('Browser not supported', this.browser);
+                console.warn('Advanced logging is not supported in browser', this.browser);
         } 
         return header;
     }
@@ -433,7 +433,7 @@ export class SpacesLoggingService {
                 index = 2;
                 break;
             default:
-                this.warn('Browser not supported', this.browser);
+                console.warn('Advanced logging is not supported in browser', this.browser);
         } 
         return index;
     }

--- a/lib/spaces_logging.service.ts
+++ b/lib/spaces_logging.service.ts
@@ -228,7 +228,7 @@ export class SpacesLoggingService {
         let levelNo = this.levels[level];
         
         if (levelNo >= this._logLevel) {
-            let logStack = (new Error).stack.split('\n');
+            let logStack = ((new Error).stack || '').split('\n');
             
             if (methodIndex == undefined) {
                 methodIndex = this.methodIndex();


### PR DESCRIPTION
Edge and Internet Explorer are not supported by the Spaces Logging service, but it will try to warn using it's own functions, causing a recursion loop.

This fix does not solve the problem (IE/Edge) not being supported, but fixes the serious flaw that unsupported browsers will stop working at all.

There was also an issue where the code assumed that `error.stack` was populated as soon as it was created. This is [not true in IE](https://docs.microsoft.com/en-us/scripting/javascript/reference/stack-property-error-javascript#remarks). This fix is also simply patching so that the service does not crash.